### PR TITLE
Add `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://developers.arcgis.com/swift/api-reference/documentation/arcgis/"


### PR DESCRIPTION
Since we have the Swift SDK on [Swift Package Index](https://swiftpackageindex.com/Esri/arcgis-maps-sdk-swift), we should point users to our API Ref Doc on that page as well. Adding this file will add the "Documentation" button on our swift package index page and take users to our api ref. For more information, see [here](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/0.17.2/documentation/spimanifest/commonusecases).

The button looks like this:
![documentation-menu-link~dark](https://user-images.githubusercontent.com/74069582/232906103-539223c9-c4e6-4a17-814b-9254e6c9b898.png)